### PR TITLE
Fix: input and button interfaces

### DIFF
--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -1,15 +1,10 @@
-import { forwardRef } from 'react'
+import { ButtonHTMLAttributes, forwardRef } from 'react'
 import { cn } from '../../helpers/utils'
 import { buttonStyles } from './buttonStyles'
 
-interface ButtonProps {
-  className?: string
-  children: React.ReactNode
-  disabled?: boolean
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   intent?: 'primary' | 'secondary'
   size?: 'small' | 'medium'
-  type: 'submit' | 'button' | 'reset'
-  onClick?: (() => void) | undefined
 }
 
 export type Ref = HTMLButtonElement

--- a/src/components/inputs/Input.tsx
+++ b/src/components/inputs/Input.tsx
@@ -7,7 +7,7 @@ import { FieldError } from 'react-hook-form'
 
 interface InputProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
-  size?: 'small' | 'medium' | number | undefined
+  size?: 'small' | 'medium'
   error?: FieldError
   grow?: boolean
   hideLabel?: boolean

--- a/src/components/inputs/Input.tsx
+++ b/src/components/inputs/Input.tsx
@@ -1,23 +1,19 @@
 import { ExclamationCircleIcon } from '@heroicons/react/20/solid'
 
-import { forwardRef } from 'react'
+import { InputHTMLAttributes, forwardRef } from 'react'
 import { cn } from '../../helpers/utils'
 import { inputStyles } from './inputStyles'
 import { FieldError } from 'react-hook-form'
 
-interface InputProps {
-  className?: string
-  disabled?: boolean
+interface InputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  size?: 'small' | 'medium' | number | undefined
   error?: FieldError
   grow?: boolean
   hideLabel?: boolean
-  intent?: 'primary' | 'secondary' | 'error'
   label: string
-  name: string
-  placeholder?: string
-  size?: 'small' | 'medium'
+  intent?: 'primary' | 'secondary' | 'error'
   type: 'text' | 'email' | 'date' | 'datetime-local'
-  value?: string
 }
 
 export type Ref = HTMLInputElement
@@ -61,5 +57,4 @@ export const Input = forwardRef<Ref, InputProps>(
 )
 
 Input.displayName = 'Input'
-
 export default Input


### PR DESCRIPTION
Summary: The interfaces for `Button` and `Input` components now extend the original attributes from each native element. This reduces the need to specify specific types, and simplifies the code a bit.