### PR TITLE
Feature: Add lint and type-check scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "build": "tsc && vite build",
     "eslint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "eslint:fix": "eslint . --ext ts,tsx",
+    "lint": "npm run type-check && npm run eslint && npm run prettier",
     "prettier": "prettier --check \"./src/**/*.{ts,tsx}\"",
     "prettier:fix": "prettier --write \"./src/**/*.{ts,tsx}\"",
     "preview": "vite preview",
-    "test": "npx playwright test"
+    "test": "npx playwright test",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc && vite build",
     "eslint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "eslint:fix": "eslint . --ext ts,tsx",
+    "fix": "npm run prettier:fix && npm run eslint:fix",
     "lint": "npm run type-check && npm run eslint && npm run prettier",
     "prettier": "prettier --check \"./src/**/*.{ts,tsx}\"",
     "prettier:fix": "prettier --write \"./src/**/*.{ts,tsx}\"",


### PR DESCRIPTION
Summary: This PR adds additional `fix`, `lint` and `type-check` scripts into `package.json`. The type check script allows to find TypeScript errors and is now run in conjunction with Prettier and ESLint scripts when you execute `npm run lint`. The script `fix` will attempt to fix ESLint and Prettier errors (assuming they're automatically fixable).